### PR TITLE
fix unpack nil error

### DIFF
--- a/mysql.lua
+++ b/mysql.lua
@@ -668,7 +668,7 @@ function res.fetch(res, mode, t)
 	if packed then
 		return row
 	else
-		return true, unpack(row)
+		return true, unpack(row or {})
 	end
 end
 


### PR DESCRIPTION
When result row is nil, unpacking it will cause a lua error